### PR TITLE
Rename contact information title

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -10,7 +10,7 @@
 
         <ul>
             <li>Email：<a href="mailto:{{ site.email }}" target="_top">{{ site.email }}</a></li>
-            <li>Website：<a href="{{ site.github_url }}">{{ site.github_url }}</a></li>
+            <li>GitHub：<a href="{{ site.github_url }}">{{ site.github_url }}</a></li>
         </ul>
 
         <h2>Skill Keywords</h2>


### PR DESCRIPTION
This commits changes the title of the second contact information on the
"About" page. The reason is the displayed URL is pointing to the GitHub
profile. Moreover, it will be useless to add a link for the website
because the visitor is already on it.

Closes #19