### PR TITLE
Fix menu options on post page

### DIFF
--- a/assets/css/sidebar-post-nav.css
+++ b/assets/css/sidebar-post-nav.css
@@ -13,6 +13,8 @@
 
 .post-directory a{
     text-decoration: none;
+    display: inline-block;
+    width: 100%;
 }
 
 .post-directory dt:hover, dd:hover {


### PR DESCRIPTION
I have updated the links of the sidebar on a post page. The reason is
that the links do not fill their parents so, the user has to click on
the menu text to reach the according section. With this commit, the user
can click beside the text, the action is triggered.

Fixes #24