### PR TITLE
Rend les informations du Jumbotron "optionnelles"

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,18 +7,21 @@ css: ['index.css', 'sidebar-popular-repo.css']
     <div class="container">
         <h1>{{ site.title }}</h1>
         <div id="jumbotron-meta-info">
+            {% if site.location %}
             <span class="meta-info">
                 <span class="octicon octicon-location"></span>
                 {{ site.location }}
-            </span>
+            </span> {% endif %}
+            {% if site.company %}
             <span class="meta-info hvr-grow">
                 <span class="octicon octicon-organization"></span>
                 <a href="{{ site.company_url }}" target="_blank">{{ site.company }}</a>
-            </span>
+            </span> {% endif %}
+            {% if site.github_url %}
             <span class="meta-info hvr-grow">
                 <span class="octicon octicon-mark-github"></span>
                 <a href="{{ site.github_url }}" target="_blank">@{{ site.name }}</a>
-            </span>
+            </span> {% endif %}
         </div>
     </div>
 </section>


### PR DESCRIPTION
Si jamais *site.location*, *site.company* ou *site.github_url* ne sont pas défini (dans `_config.yml`) alors le Jumbotron n'affiche rien.

_______

Au passage, Merci beaucoup pour le travail sur le thème.

Avec respect, 
@del-r